### PR TITLE
fix(perf): stop cloning dataframes

### DIFF
--- a/src/core/engine/engine.rs
+++ b/src/core/engine/engine.rs
@@ -78,13 +78,17 @@ impl Engine {
 
                 let mut result: Option<Vec<Dataframe>> = None;
                 for transformation in pipeline.iter() {
-                    // first transformation, using source dataframes
-                    if result.is_none() {
-                        result = Some(transformation.transform(&source_dataframes));
-                    } else {
-                        let dfs = result.unwrap();
-                        let refs = dfs.iter().collect::<Vec<_>>();
-                        result = Some(transformation.transform(&refs));
+                    match result {
+                        None => {
+                            // if we are in this arm, we are doing the first transformation in the pipeline; so we take
+                            // the source dataframes as our input
+                            result = Some(transformation.transform(&source_dataframes));
+                        }
+                        Some(previous_result) => {
+                            // otherwise, we apply the current transformation to the previous result
+                            let refs = previous_result.iter().collect();
+                            result = Some(transformation.transform(&refs));
+                        }
                     }
                 }
                 (name.clone(), result.unwrap_or(vec![]))

--- a/src/core/engine/engine.rs
+++ b/src/core/engine/engine.rs
@@ -10,10 +10,10 @@ use crate::{
     transformations::{Filter, InnerJoin, Transformation},
 };
 
-fn build_pipeline(
-    definition: &TransformationDefinition,
-    context: &Context,
-) -> Vec<Box<dyn Transformation>> {
+fn build_pipeline<'a>(
+    definition: &'a TransformationDefinition,
+    context: &'a Context,
+) -> impl Iterator<Item = Box<dyn Transformation>> + 'a {
     definition
         .operations
         .iter()
@@ -24,7 +24,6 @@ fn build_pipeline(
             };
             op
         })
-        .collect()
 }
 
 /// The engine is the entry point for running a pipeline. It is constructed based on a pipeline definition.
@@ -77,7 +76,7 @@ impl Engine {
                     .collect();
 
                 let mut result: Option<Vec<Dataframe>> = None;
-                for transformation in pipeline.iter() {
+                for transformation in pipeline {
                     match result {
                         None => {
                             // if we are in this arm, we are doing the first transformation in the pipeline; so we take

--- a/src/core/engine/engine.rs
+++ b/src/core/engine/engine.rs
@@ -14,16 +14,13 @@ fn build_pipeline<'a>(
     definition: &'a TransformationDefinition,
     context: &'a Context,
 ) -> impl Iterator<Item = Box<dyn Transformation>> + 'a {
-    definition
-        .operations
-        .iter()
-        .map(|def| {
-            let op: Box<dyn Transformation> = match def {
-                Operation::Filter { predicate } => Box::new(Filter::new(predicate, context)),
-                Operation::InnerJoin { on } => Box::new(InnerJoin::new(on)),
-            };
-            op
-        })
+    definition.operations.iter().map(|def| {
+        let op: Box<dyn Transformation> = match def {
+            Operation::Filter { predicate } => Box::new(Filter::new(predicate, context)),
+            Operation::InnerJoin { on } => Box::new(InnerJoin::new(on)),
+        };
+        op
+    })
 }
 
 /// The engine is the entry point for running a pipeline. It is constructed based on a pipeline definition.
@@ -69,7 +66,7 @@ impl Engine {
             .par_iter()
             .map(|(name, definition)| {
                 let pipeline = build_pipeline(definition, context);
-                let source_dataframes: Vec<&Dataframe> = definition
+                let source_dataframes = definition
                     .sources
                     .iter()
                     .map(|source| dfs.get(source).unwrap())

--- a/src/core/transformations/filter.rs
+++ b/src/core/transformations/filter.rs
@@ -71,8 +71,8 @@ impl Filter {
 }
 
 impl Transformation for Filter {
-    fn transform(&self, dfs: Vec<Dataframe>) -> Vec<Dataframe> {
-        vec![(self.apply)(&dfs[0])]
+    fn transform(&self, dfs: &Vec<&Dataframe>) -> Vec<Dataframe> {
+        vec![(self.apply)(dfs[0])]
     }
 }
 
@@ -96,8 +96,10 @@ mod test {
     #[test]
     fn filter_gt() {
         let op = Filter::new("foo > 1", &ctx(HashMap::default()));
+        let dfs = df();
+        let df_refs = dfs.iter().collect();
 
-        let result = op.transform(df());
+        let result = op.transform(&df_refs);
 
         assert_eq!(
             result[0],
@@ -112,7 +114,10 @@ mod test {
     fn filter_gte() {
         let op = Filter::new("foo >= 1", &ctx(HashMap::default()));
 
-        let result = op.transform(df());
+        let dfs = df();
+        let df_refs = dfs.iter().collect();
+
+        let result = op.transform(&df_refs);
 
         assert_eq!(
             result[0],
@@ -126,8 +131,10 @@ mod test {
     #[test]
     fn filter_lt() {
         let op = Filter::new("foo < 1", &ctx(HashMap::default()));
+        let dfs = df();
+        let df_refs = dfs.iter().collect();
 
-        let result = op.transform(df());
+        let result = op.transform(&df_refs);
 
         assert_eq!(
             result[0],
@@ -141,8 +148,10 @@ mod test {
     #[test]
     fn filter_lte() {
         let op = Filter::new("foo <= 1", &ctx(HashMap::default()));
+        let dfs = df();
+        let df_refs = dfs.iter().collect();
 
-        let result = op.transform(df());
+        let result = op.transform(&df_refs);
 
         assert_eq!(
             result[0],
@@ -156,8 +165,10 @@ mod test {
     #[test]
     fn filter_eq() {
         let op = Filter::new("foo == 1", &ctx(HashMap::default()));
+        let dfs = df();
+        let df_refs = dfs.iter().collect();
 
-        let result = op.transform(df());
+        let result = op.transform(&df_refs);
 
         assert_eq!(
             result[0],
@@ -171,8 +182,10 @@ mod test {
     #[test]
     fn filter_ne() {
         let op = Filter::new("foo != 1", &ctx(HashMap::default()));
+        let dfs = df();
+        let df_refs = dfs.iter().collect();
 
-        let result = op.transform(df());
+        let result = op.transform(&df_refs);
 
         assert_eq!(
             result[0],
@@ -189,8 +202,10 @@ mod test {
             "foo != :param_name",
             &ctx(HashMap::from([("param_name".to_owned(), "1".to_owned())])),
         );
+        let dfs = df();
+        let df_refs = dfs.iter().collect();
 
-        let result = op.transform(df());
+        let result = op.transform(&df_refs);
 
         assert_eq!(
             result[0],

--- a/src/core/transformations/inner_join.rs
+++ b/src/core/transformations/inner_join.rs
@@ -80,8 +80,8 @@ impl InnerJoin {
 }
 
 impl Transformation for InnerJoin {
-    fn transform(&self, dfs: Vec<Dataframe>) -> Vec<Dataframe> {
-        vec![(self.apply)(&dfs[0], &dfs[1])]
+    fn transform(&self, dfs: &Vec<&Dataframe>) -> Vec<Dataframe> {
+        vec![(self.apply)(dfs[0], dfs[1])]
     }
 }
 
@@ -124,7 +124,9 @@ mod test {
 
         let op = InnerJoin::new("id = id");
 
-        let result = op.transform(dfs);
+        let df_refs = dfs.iter().collect();
+
+        let result = op.transform(&df_refs);
         assert_eq!(result[0], vec![])
     }
 
@@ -142,8 +144,9 @@ mod test {
         ];
 
         let op = InnerJoin::new("non_existing = non_existing");
+        let df_refs = dfs.iter().collect();
 
-        let result = op.transform(dfs);
+        let result = op.transform(&df_refs);
         assert_eq!(result[0], vec![])
     }
 
@@ -174,7 +177,9 @@ mod test {
 
         let op = InnerJoin::new("id = id");
 
-        let result = op.transform(dfs);
+        let df_refs = dfs.iter().collect();
+
+        let result = op.transform(&df_refs);
         assert_eq!(
             result[0],
             vec![
@@ -213,7 +218,9 @@ mod test {
 
         let op = InnerJoin::new("id = id");
 
-        let result = op.transform(dfs);
+        let df_refs = dfs.iter().collect();
+
+        let result = op.transform(&df_refs);
         assert_eq!(
             result[0],
             vec![
@@ -252,7 +259,9 @@ mod test {
 
         let op = InnerJoin::new("id = id");
 
-        let result = op.transform(dfs);
+        let df_refs = dfs.iter().collect();
+
+        let result = op.transform(&df_refs);
         assert_eq!(
             result[0],
             vec![
@@ -285,7 +294,9 @@ mod test {
 
         let op = InnerJoin::new("id = id");
 
-        let result = op.transform(dfs);
+        let df_refs = dfs.iter().collect();
+
+        let result = op.transform(&df_refs);
         assert_eq!(
             result[0],
             vec![HashMap::from([
@@ -311,7 +322,9 @@ mod test {
 
         let op = InnerJoin::new("id = id");
 
-        let result = op.transform(dfs);
+        let df_refs = dfs.iter().collect();
+
+        let result = op.transform(&df_refs);
         assert_eq!(result[0], vec![],)
     }
 }

--- a/src/core/transformations/transformation.rs
+++ b/src/core/transformations/transformation.rs
@@ -4,5 +4,5 @@ use crate::core::dataframe::Dataframe;
 /// Each individual transformation will have its own semantics about what it expects as its vector of inputs, as
 /// well as the arity of this vector.
 pub trait Transformation {
-    fn transform(&self, dfs: Vec<Dataframe>) -> Vec<Dataframe>;
+    fn transform(&self, dfs: &Vec<&Dataframe>) -> Vec<Dataframe>;
 }


### PR DESCRIPTION
This addresses issue #5.

We were cloning the input data frames at the start of each transformation, to pass it into the fold. This is because the transformation trait was defined as `Vec<Dataframe> -> Vec<Dataframe>`. While this was handy for composition, it meant that at th estart of the pipeline we needed to provide an owned dataframe, leading to a `clone` that could become very expensive as the size of the data frame increases.
